### PR TITLE
build ghc in the image // better caching // faster development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 FROM ubuntu:22.04
 
+ARG GHC_VERSION=9.10.2
+
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y build-essential curl libffi-dev libffi8ubuntu1 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5 libnuma1 git libnuma-dev llvm zlib1g-dev \
@@ -16,4 +18,5 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | \
 
 ENV PATH=$PATH:/home/haskell/.ghcup/bin
 RUN ghcup install stack
+RUN stack setup ${GHC_VERSION}
 WORKDIR /work


### PR DESCRIPTION
> [!NOTE]
> this has anti-patterns[^1]. not ideal for upstream. good for learning

as is, the image installs `ghcup` and `stack` but not the actual compiler i.e `ghc`.
`ghc` is downloaded and **built** on the first run of `stack repl`
[[see VOD @ 3:09:45]](https://www.youtube.com/live/bG_N0cw2Bno?&t=11385)

the whole process takes a good amount of time and is repeated with every new
container spun up using the image

with this patch, `stack setup` is run while the building of the Docker image itself.
and `stack setup` in turn downloads and builds ghc according to the build arg `GHC_VERSION` [docs for `stack setup`](https://docs.haskellstack.org/en/stable/commands/setup_command/)

i've set the defualt value of `GHC_VERSION` to `9.10.2` as that's what downloaded on stream. so you can just do `docker build -t learning-haskell .` as usual

<details>
<summary>ASIDE: specifying a different version of GHC</summary>

to build the Docker image with a different version of GHC, use

```console
$ docker build -t learning-haskell --build-arg GHC_VERSION=9.8.4
```

you probably want `-t learning-haskell:ghc9.8.4`

</details>

[^1]: ideally a Dockerfile would be unique to a project and download the version of ghc _configured for the project_
